### PR TITLE
All api functions accept same credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ INSTALLED_APPS = (
 Optional
 
 ```python
-RESIGNER_API_MAX_DELAY = 1 # max delay in seconds
+RESIGNER_API_MAX_DELAY = 30 # max delay in seconds (default 5*60 seconds)
 ```
 
 ## Usage (in progress)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # Resigner doc
 
+## What it does
+Signes API requests: each _client_ is identified by its key and granted access by a secret.
+(no secret transmitted over to _server_ - used only to sign a request)
+
 ## How to install
 
 ```
@@ -36,15 +40,14 @@ from django.http import JsonResponse
 
 from resigner.server import signed_req_required
 
-@signed_req_required("MY_API_KEY")
+@signed_req_required
 def my_api_view(request):
     resp = {"result": "this API has been protected with secret key"}
     return JsonResponse(resp)
 ```
 
 Add through admin:
-* in `ApiKeys` (this identifies the API): _MY_API_KEY_ (key) and _my_secret_key_ (secret)
-* in `ApiClients` (this identifies the client): _MY_TEST_CLIENT_ (name) _and my_client_key_ (key)
+* in `ApiKeys`: _MY_API_KEY_ (key, used to identify a client) and _my_secret_key_ (secret, used to get access)
 
 
 ### Client
@@ -53,7 +56,7 @@ Add through admin:
 ```python
 ...
 res = post_signed(
-    "http://mysite/api_url", {"key": "val"}, "my_client_key", "my_secret_key"
+    "http://mysite/api_url", {"some": "data_we_want_to_transmit"}, "my_client_key", "my_secret_key"
 )
 
 if res.status_code == 200:

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ def my_api_view(request):
 Add through admin:
 * in `ApiKeys`: _MY_API_KEY_ (key, used to identify a client) and _my_secret_key_ (secret, used to get access)
 
+You may use auto generated or provide specific value.
+
 
 ### Client
-
 
 ```python
 ...

--- a/resigner/admin.py
+++ b/resigner/admin.py
@@ -1,11 +1,7 @@
-from .models import ApiKey, ApiClient
+from .models import ApiKey
 from django.contrib import admin
 
 class ApiKeyAdmin(admin.ModelAdmin):
     list_display = ("name", "key")
-    
-class ApiClientAdmin(admin.ModelAdmin):
-    list_display = ("name", "key")
 
 admin.site.register(ApiKey, ApiKeyAdmin)
-admin.site.register(ApiClient, ApiClientAdmin)

--- a/resigner/client.py
+++ b/resigner/client.py
@@ -3,24 +3,17 @@ import urllib
 import urlparse
 from requests import Request, Session
 
-from django.core.signing import Signer
-
-from .utils import data_hash
-from .utils import data_hash, get_settings_param, \
+from .utils import get_signature, get_settings_param, \
     CLIENT_TIME_STAMP_KEY, CLIENT_API_SIGNATURE_KEY, CLIENT_API_KEY
-
 
 def _get_security_headers(req_body, key, secret, url,
                          header_api_key=CLIENT_API_SIGNATURE_KEY):
     time_stamp = str(int(time.time()))
-
-    value = Signer(key=secret).sign(
-        data_hash(req_body, time_stamp, url)
-    )
+    signature = get_signature(secret, req_body, time_stamp, url)
 
     return {
         CLIENT_API_KEY: key, # uniquely identifies client
-        header_api_key: value,
+        header_api_key: signature,
         CLIENT_TIME_STAMP_KEY: time_stamp
     }
 

--- a/resigner/client.py
+++ b/resigner/client.py
@@ -1,4 +1,6 @@
 import time
+import urllib
+import urlparse
 from requests import Request, Session
 
 from django.core.signing import Signer
@@ -22,7 +24,19 @@ def _get_security_headers(req_body, key, secret, url,
         CLIENT_TIME_STAMP_KEY: time_stamp
     }
 
+def _append_dict_params(url, params):
+    url_parts = list(urlparse.urlparse(url))
+    query = dict(urlparse.parse_qsl(url_parts[4]))
+    query.update(params)
+
+    url_parts[4] = urllib.urlencode(query)
+
+    return urlparse.urlunparse(url_parts)
+
 def _create_signed_req(method, url, data, key, secret):
+    if method == "GET" and data and isinstance(data, dict):
+        url = _append_dict_params(url, data)
+
     req = Request(method, url, data=data)
 
     prepped = req.prepare()

--- a/resigner/client.py
+++ b/resigner/client.py
@@ -8,26 +8,26 @@ from .utils import data_hash, get_settings_param, \
     CLIENT_TIME_STAMP_KEY, CLIENT_API_SIGNATURE_KEY, CLIENT_API_KEY
 
 
-def _get_security_headers(req_body, x_api_key, api_secret_key, url,
+def _get_security_headers(req_body, key, secret, url,
                          header_api_key=CLIENT_API_SIGNATURE_KEY):
     time_stamp = str(int(time.time()))
 
-    value = Signer(key=api_secret_key).sign(
+    value = Signer(key=secret).sign(
         data_hash(req_body, time_stamp, url)
     )
 
     return {
-        CLIENT_API_KEY: x_api_key, # uniquely identifies client
+        CLIENT_API_KEY: key, # uniquely identifies client
         header_api_key: value,
         CLIENT_TIME_STAMP_KEY: time_stamp
     }
 
-def _create_signed_req(method, url, data, x_api_key, api_secret_key):
+def _create_signed_req(method, url, data, key, secret):
     req = Request(method, url, data=data)
 
     prepped = req.prepare()
     prepped.headers.update(
-        _get_security_headers(prepped.body, x_api_key, api_secret_key, url)
+        _get_security_headers(prepped.body, key, secret, url)
     )
 
     return prepped
@@ -35,17 +35,17 @@ def _create_signed_req(method, url, data, x_api_key, api_secret_key):
 def _send_req(req):
     return Session().send(req)
 
-def _send_signed_req(method, url, data, x_api_key, api_secret_key):
+def _send_signed_req(method, url, data, key, secret):
     return _send_req(
-        _create_signed_req(method, url, data, x_api_key, api_secret_key)
+        _create_signed_req(method, url, data, key, secret)
     )
 
-def post_signed(url, data, x_api_key, api_secret_key):
+def post_signed(url, data, key, secret):
     return _send_signed_req(
-        "POST", url, data, x_api_key, api_secret_key
+        "POST", url, data, key, secret
     )
 
-def get_signed(url, data, x_api_key, api_secret_key):
+def get_signed(url, data, key, secret):
     return _send_signed_req(
-        "GET", url, data, x_api_key, api_secret_key
+        "GET", url, data, key, secret
     )

--- a/resigner/client.py
+++ b/resigner/client.py
@@ -1,7 +1,7 @@
 import time
 from requests import Request, Session
 
-from django.core import signing
+from django.core.signing import Signer
 
 from .utils import data_hash
 from .utils import data_hash, get_settings_param, \
@@ -11,9 +11,10 @@ from .utils import data_hash, get_settings_param, \
 def _get_security_headers(req_body, x_api_key, api_secret_key, url,
                          header_api_key=CLIENT_API_SIGNATURE_KEY):
     time_stamp = str(int(time.time()))
-    key = api_secret_key + data_hash(req_body, time_stamp, url)
 
-    value = signing.dumps(x_api_key, key=key)
+    value = Signer(key=api_secret_key).sign(
+        data_hash(req_body, time_stamp, url)
+    )
 
     return {
         CLIENT_API_KEY: x_api_key, # uniquely identifies client

--- a/resigner/client.py
+++ b/resigner/client.py
@@ -3,7 +3,7 @@ import urllib
 import urlparse
 from requests import Request, Session
 
-from .utils import get_signature, get_settings_param, \
+from .utils import get_signature, \
     CLIENT_TIME_STAMP_KEY, CLIENT_API_SIGNATURE_KEY, CLIENT_API_KEY
 
 def _get_security_headers(req_body, key, secret, url,

--- a/resigner/client.py
+++ b/resigner/client.py
@@ -24,24 +24,15 @@ def _get_security_headers(req_body, key, secret, url,
         CLIENT_TIME_STAMP_KEY: time_stamp
     }
 
-def _append_dict_params(url, params):
-    url_parts = list(urlparse.urlparse(url))
-    query = dict(urlparse.parse_qsl(url_parts[4]))
-    query.update(params)
-
-    url_parts[4] = urllib.urlencode(query)
-
-    return urlparse.urlunparse(url_parts)
-
 def _create_signed_req(method, url, data, key, secret):
-    if method == "GET" and data and isinstance(data, dict):
-        url = _append_dict_params(url, data)
-
-    req = Request(method, url, data=data)
+    if method == "POST":
+        req = Request(method, url, data=data)
+    else:
+        req = Request(method, url, params=data)
 
     prepped = req.prepare()
     prepped.headers.update(
-        _get_security_headers(prepped.body, key, secret, url)
+        _get_security_headers(prepped.body, key, secret, prepped.url)
     )
 
     return prepped

--- a/resigner/migrations/0004_auto_20150621_0920.py
+++ b/resigner/migrations/0004_auto_20150621_0920.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import resigner.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resigner', '0003_auto_20150616_0426'),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name='ApiClient',
+        ),
+        migrations.AlterField(
+            model_name='apikey',
+            name='key',
+            field=models.CharField(default=resigner.models.mk_key, max_length=32),
+        ),
+        migrations.AlterField(
+            model_name='apikey',
+            name='secret',
+            field=models.CharField(default=resigner.models.mk_secret, max_length=256),
+        ),
+    ]

--- a/resigner/models.py
+++ b/resigner/models.py
@@ -1,10 +1,13 @@
-from django.db import models
 import random
 import string
 
+from django.db import models
 
 def random_string(length):
-    return ''.join(random.choice(_chars_for_secret) for _ in range(length))
+    return ''.join(
+        random.SystemRandom().choice(string.ascii_letters + string.digits)
+        for _ in range(length)
+    )
     
 def mk_key():
     return random_string(24)

--- a/resigner/models.py
+++ b/resigner/models.py
@@ -20,10 +20,3 @@ class ApiKey(models.Model):
 
     def __unicode__(self):
         return "%s [%s]" % (self.key, self.id)
-
-class ApiClient(models.Model):
-    name = models.CharField(max_length=200, unique=True)
-    key = models.CharField(max_length=32, unique=True, default=mk_key)
-
-    def __unicode__(self):
-        return "%s [%s]" % (self.name, self.id)

--- a/resigner/server.py
+++ b/resigner/server.py
@@ -8,7 +8,7 @@ from django.http import Http404, HttpResponseBadRequest
 from django.core.signing import Signer
 
 from .models import ApiKey
-from .utils import data_hash, get_settings_param, \
+from .utils import get_signature, get_settings_param, \
     SERVER_TIME_STAMP_KEY, SERVER_API_SIGNATURE_KEY, SERVER_API_KEY
 
 def signed_req_required(view_func):
@@ -49,9 +49,9 @@ def signed_req_required(view_func):
             try:
                 time_stamp = request.META[SERVER_TIME_STAMP_KEY]
                 url = request.build_absolute_uri()
-                value = data_hash(request.body, time_stamp, url)
+                expected_signature = get_signature(api_client.secret, request.body, time_stamp, url)
 
-                if value == Signer(key=api_client.secret).unsign(api_signature):
+                if api_signature == expected_signature:
                     return True
 
             except:

--- a/resigner/server.py
+++ b/resigner/server.py
@@ -36,7 +36,7 @@ def signed_req_required(api_secret_key_name):
                     return False
                 received_times_stamp = request.META[SERVER_TIME_STAMP_KEY]
 
-                max_delay = get_settings_param("RESIGNER_TIME_STAMP_MAX_DELAY", 5*60)
+                max_delay = get_settings_param("RESIGNER_API_MAX_DELAY", 5*60)
                 time_stamp_now = time.time()
 
                 return (

--- a/resigner/server.py
+++ b/resigner/server.py
@@ -11,65 +11,62 @@ from .models import ApiKey
 from .utils import data_hash, get_settings_param, \
     SERVER_TIME_STAMP_KEY, SERVER_API_SIGNATURE_KEY, SERVER_API_KEY
 
-def signed_req_required(api_secret_key_name):
+def signed_req_required(view_func):
 
-    def _signed_req_required(view_func):
+    def check_signature(request, *args, **kwargs):
 
-        def check_signature(request, *args, **kwargs):
+        def identify_api_client():
+            api_client = None
 
-            def identify_api_client():
-                api_client = None
-
-                if not SERVER_API_KEY in request.META.keys():
-                    return api_client
-
-                client_identification = request.META[SERVER_API_KEY]
-                try:
-                    api_client = ApiKey.objects.get(key=client_identification)
-                except ApiKey.DoesNotExist:
-                    time.sleep(1) # rate limiting
-
+            if not SERVER_API_KEY in request.META.keys():
                 return api_client
 
-            def is_time_stamp_valid():
-                if not SERVER_TIME_STAMP_KEY in request.META.keys():
-                    return False
-                received_times_stamp = request.META[SERVER_TIME_STAMP_KEY]
+            client_identification = request.META[SERVER_API_KEY]
+            try:
+                api_client = ApiKey.objects.get(key=client_identification)
+            except ApiKey.DoesNotExist:
+                time.sleep(1) # rate limiting
 
-                max_delay = get_settings_param("RESIGNER_API_MAX_DELAY", 5*60)
-                time_stamp_now = time.time()
+            return api_client
 
-                return (
-                    abs(int(time_stamp_now) - int(received_times_stamp)) < max_delay
-                )
-
-            def is_signature_ok():
-                if not SERVER_API_SIGNATURE_KEY in request.META.keys():
-                    return False
-                api_signature = request.META[SERVER_API_SIGNATURE_KEY]
-
-                try:
-                    time_stamp = request.META[SERVER_TIME_STAMP_KEY]
-                    url = request.build_absolute_uri()
-                    value = data_hash(request.body, time_stamp, url)
-
-                    if value == Signer(key=api_client.secret).unsign(api_signature):
-                        return True
-
-                except:
-                    pass
-
+        def is_time_stamp_valid():
+            if not SERVER_TIME_STAMP_KEY in request.META.keys():
                 return False
+            received_times_stamp = request.META[SERVER_TIME_STAMP_KEY]
 
-            api_client = identify_api_client()
-            if not api_client:
-               return HttpResponseBadRequest("The API KEY used in this request does not exist")
+            max_delay = get_settings_param("RESIGNER_API_MAX_DELAY", 5*60)
+            time_stamp_now = time.time()
 
-            if is_time_stamp_valid() and is_signature_ok():
-                return view_func(request, *args, **kwargs)
-            else:
-                raise Http404
+            return (
+                abs(int(time_stamp_now) - int(received_times_stamp)) < max_delay
+            )
 
-        return wraps(view_func)(check_signature)
+        def is_signature_ok():
+            if not SERVER_API_SIGNATURE_KEY in request.META.keys():
+                return False
+            api_signature = request.META[SERVER_API_SIGNATURE_KEY]
 
-    return _signed_req_required
+            try:
+                time_stamp = request.META[SERVER_TIME_STAMP_KEY]
+                url = request.build_absolute_uri()
+                value = data_hash(request.body, time_stamp, url)
+
+                if value == Signer(key=api_client.secret).unsign(api_signature):
+                    return True
+
+            except:
+                pass
+
+            return False
+
+        api_client = identify_api_client()
+        if not api_client:
+           return HttpResponseBadRequest("The API KEY used in this request does not exist")
+
+        if is_time_stamp_valid() and is_signature_ok():
+            return view_func(request, *args, **kwargs)
+        else:
+            raise Http404
+
+    return wraps(view_func)(check_signature)
+

--- a/resigner/utils.py
+++ b/resigner/utils.py
@@ -1,6 +1,7 @@
 import hashlib
 
 from django.conf import settings
+from django.core.signing import Signer
 
 HEADER_KEY_PREFIX = "RESIGNER"
 
@@ -15,13 +16,12 @@ SERVER_TIME_STAMP_KEY = to_server_key(CLIENT_TIME_STAMP_KEY)
 SERVER_API_SIGNATURE_KEY = to_server_key(CLIENT_API_SIGNATURE_KEY)
 SERVER_API_KEY = to_server_key(CLIENT_API_KEY)
 
-def data_hash(req_body, time_stamp, url):
-    if not req_body:
-        req_body = ""
+def get_signature(secret, body, timestamp, url):
+    if not body:
+        body = ""
 
-    hash = hashlib.sha1()
-    hash.update(req_body + time_stamp + url)
-    return hash.hexdigest()[:10]
+    signer = Signer(key=secret)
+    return signer.signature( ":".join([body, timestamp, url]) )
 
 def get_settings_param(name, default=0):
     if hasattr(settings, name):

--- a/resigner/utils.py
+++ b/resigner/utils.py
@@ -16,6 +16,9 @@ SERVER_API_SIGNATURE_KEY = to_server_key(CLIENT_API_SIGNATURE_KEY)
 SERVER_API_KEY = to_server_key(CLIENT_API_KEY)
 
 def data_hash(req_body, time_stamp, url):
+    if not req_body:
+        req_body = ""
+
     hash = hashlib.sha1()
     hash.update(req_body + time_stamp + url)
     return hash.hexdigest()[:10]

--- a/test_project/resigner_tests/tests.py
+++ b/test_project/resigner_tests/tests.py
@@ -158,6 +158,24 @@ class TestSignedApiBase(object):
         # all signatures are different
         self.assertEqual(len(set(signatures)), 3)
 
+    def assert_200_res_no_data(self, res):
+        self.assertEqual(res.status_code, 200)
+        self.assertApiResult(res, "no data received")
+
+    def test_api_result_ok_answer_not_ok(self):
+        self.assert_200_res_no_data(
+            self.call_api(
+                data={u"SOMETHING_UNEXPECTED": u"some_val"}
+            )
+        )
+
+    def test_api_result_ok_empty_data(self):
+        empty_req_body = [None, {}, ""]
+
+        for body in empty_req_body:
+            self.assert_200_res_no_data(
+                self.call_api(data=body)
+            )
 
 class TestSignedApiGet(LiveServerTestCase, TestSignedApiBase):
     method_name = "GET"
@@ -177,22 +195,3 @@ class TestSignedApiPost(LiveServerTestCase, TestSignedApiBase):
 
     def api_func(self):
         return post_signed
-
-    def assert_200_res_no_data(self, res):
-        self.assertEqual(res.status_code, 200)
-        self.assertApiResult(res, "no data received")
-
-    def test_api_result_ok_answer_not_ok(self):
-        self.assert_200_res_no_data(
-            self.call_api(
-                data={u"SOMETHING_UNEXPECTED": u"some_val"}
-            )
-        )
-
-    def test_api_result_ok_empty_data(self):
-        empty_req_body = [None, {}, ""]
-
-        for body in empty_req_body:
-            self.assert_200_res_no_data(
-                self.call_api(data=body)
-            )

--- a/test_project/resigner_tests/tests.py
+++ b/test_project/resigner_tests/tests.py
@@ -50,15 +50,29 @@ class TestSignedApiBase(object):
         }
 
     def call_api(self, data=None, key=None, secret=None):
-
         kwargs = self.get_api_params(data, key, secret)
 
         return self.api_func()(**kwargs)
 
-
     def test_api_result_ok(self):
         self.assert_200_res_ok(
             self.call_api()
+        )
+
+    def test_api_result_ok_specific_key_secret(self):
+        ApiKey.objects.all().delete()
+        self.assertEqual(ApiKey.objects.all().count(), 0)
+
+        api_key = ApiKey.objects.create(
+            key="some_specific_key_873#28hh27832",
+            secret="some_specific_secret_gsY73#28hh27__2",
+        )
+
+        self.assert_200_res_ok(
+            self.call_api(
+                key=api_key.key,
+                secret=api_key.secret
+            )
         )
 
     def test_api_result_ok_dummy_param(self):
@@ -74,7 +88,6 @@ class TestSignedApiBase(object):
     def test_wrong_secret(self):
         res = self.call_api(secret="wrong_secret")
         self.assertEqual(res.status_code, 404)
-
 
     def deconstructed_client_api_call(self, callback_func=None):
         params = self.get_api_params()
@@ -103,7 +116,6 @@ class TestSignedApiBase(object):
         res = self.deconstructed_client_api_call(simulate_missing_header)
 
         self.assertEqual(res.status_code, 404)
-
 
     def selfAssertTimeStampDiff(self, diff, result):
         def simulate_outdated_timestamp(req):
@@ -134,7 +146,6 @@ class TestSignedApiBase(object):
         res = self.deconstructed_client_api_call(simulate_missing_header)
 
         self.assertEqual(res.status_code, 404)
-
 
     def test_signature_changes_each_second(self):
         signatures = []

--- a/test_project/resigner_tests/tests.py
+++ b/test_project/resigner_tests/tests.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 from django.test.client import Client
 from django.conf import settings
 
-from resigner.models import ApiKey, ApiClient
+from resigner.models import ApiKey
 from resigner.client import post_signed, get_signed, _send_req, _create_signed_req
 from resigner.utils import CLIENT_TIME_STAMP_KEY, CLIENT_API_SIGNATURE_KEY
 
@@ -17,13 +17,8 @@ class TestSignedApiBase(object):
         self.api_key_secret_value = "some_test_secret_value"
 
         ApiKey.objects.create(
-            key="MY_API_KEY",
-            secret=self.api_key_secret_value,
-        )
-
-        ApiClient.objects.create(
-            name="My test client",
             key=settings.TEST_RESIGNER_X_API_KEY,
+            secret=self.api_key_secret_value,
         )
 
         self.url = self.live_server_url + reverse("my_test_api")

--- a/test_project/resigner_tests/tests.py
+++ b/test_project/resigner_tests/tests.py
@@ -28,12 +28,8 @@ class TestSignedApiBase(object):
         self.assertEqual(res.status_code, 200)
         self.assertApiResult(res, "test ok")
 
-    def get_api_params(self, data=None,
-                 api_key=None,
-                 api_secret=None):
-
-
-        if data == None:
+    def get_api_params(self, data="default", api_key=None, api_secret=None):
+        if data == "default":
             data = {u"MY_TEST_DATA": u"hello from test script!"}
 
         if api_key == None:
@@ -49,7 +45,7 @@ class TestSignedApiBase(object):
             "api_secret_key": api_secret,
         }
 
-    def call_api(self, data=None, key=None, secret=None):
+    def call_api(self, data="default", key=None, secret=None):
         kwargs = self.get_api_params(data, key, secret)
 
         return self.api_func()(**kwargs)
@@ -182,8 +178,21 @@ class TestSignedApiPost(LiveServerTestCase, TestSignedApiBase):
     def api_func(self):
         return post_signed
 
-    def test_api_result_ok_answer_not_ok(self):
-        res = self.call_api({u"SOMETHING_UNEXPECTED": u"some_val"})
-
+    def assert_200_res_no_data(self, res):
         self.assertEqual(res.status_code, 200)
         self.assertApiResult(res, "no data received")
+
+    def test_api_result_ok_answer_not_ok(self):
+        self.assert_200_res_no_data(
+            self.call_api(
+                data={u"SOMETHING_UNEXPECTED": u"some_val"}
+            )
+        )
+
+    def test_api_result_ok_empty_data(self):
+        empty_req_body = [None, {}, ""]
+
+        for body in empty_req_body:
+            self.assert_200_res_no_data(
+                self.call_api(data=body)
+            )

--- a/test_project/resigner_tests/tests.py
+++ b/test_project/resigner_tests/tests.py
@@ -41,8 +41,8 @@ class TestSignedApiBase(object):
         return {
             "url": self.url,
             "data": data,
-            "x_api_key": api_key,
-            "api_secret_key": api_secret,
+            "key": api_key,
+            "secret": api_secret,
         }
 
     def call_api(self, data="default", key=None, secret=None):

--- a/test_project/resigner_tests/views.py
+++ b/test_project/resigner_tests/views.py
@@ -10,6 +10,6 @@ def my_test_api_view(request):
     req = request.POST if is_post else request.GET
     test_data = req.get("MY_TEST_DATA", "")
 
-    result = "test ok" if test_data or not is_post else "no data received"
+    result = "test ok" if test_data else "no data received"
 
     return JsonResponse({"result":result})

--- a/test_project/resigner_tests/views.py
+++ b/test_project/resigner_tests/views.py
@@ -3,7 +3,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from resigner.server import signed_req_required
 
-@signed_req_required("MY_API_KEY")
+@signed_req_required
 @csrf_exempt
 def my_test_api_view(request):
     is_post = (request.method == 'POST')

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -9,7 +9,7 @@ TEMPLATE_DEBUG = DEBUG
 
 SECRET_KEY = "thisIsTotallyASecretJkLolHaHa!1!!1!"
 
-TEST_RESIGNER_X_API_KEY = "some_per_client_x_api_key"
+TEST_RESIGNER_X_API_KEY = "this_is_how_im_identified_8712bhjds"
 
 RESIGNER_API_MAX_DELAY = 1
 

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -9,8 +9,6 @@ TEMPLATE_DEBUG = DEBUG
 
 SECRET_KEY = "thisIsTotallyASecretJkLolHaHa!1!!1!"
 
-TEST_RESIGNER_X_API_KEY = "this_is_how_im_identified_8712bhjds"
-
 RESIGNER_API_MAX_DELAY = 1
 
 DATABASES = {


### PR DESCRIPTION
Client is identified through his _key_ and access is granted through _secret_ (never sent over, just used for signing)

Deployment requires some downtime (ideally during off hours)