### PR TITLE
Fix small ts delay timeout

### DIFF
--- a/resigner/client.py
+++ b/resigner/client.py
@@ -6,7 +6,7 @@ from .utils import get_signature, \
 
 def _get_security_headers(req_body, key, secret, url,
                          header_api_key=CLIENT_API_SIGNATURE_KEY):
-    time_stamp = str(int(time.time()))
+    time_stamp = "{0:.4f}".format(time.time())
     signature = get_signature(secret, req_body, time_stamp, url)
 
     return {

--- a/resigner/server.py
+++ b/resigner/server.py
@@ -33,15 +33,12 @@ def signed_req_required(view_func):
             max_delay = get_settings_param("RESIGNER_API_MAX_DELAY", 5*60)
             time_stamp_now = time.time()
 
-            ts_valid = (
-                abs(int(time_stamp_now) - int(received_times_stamp)) < max_delay
+            return (
+                abs(time_stamp_now - float(received_times_stamp)) < max_delay
             )
-            print("ts_valid {}".format(ts_valid))
-            return ts_valid
 
         def is_signature_ok():
             if not SERVER_API_SIGNATURE_KEY in request.META.keys():
-                print("is_signature_nok1")
                 return False
             api_signature = request.META[SERVER_API_SIGNATURE_KEY]
 
@@ -58,10 +55,7 @@ def signed_req_required(view_func):
                 if api_signature == expected_signature:
                     return True
 
-                print("is_signature_nok2")
-
             except:
-                print("is_signature_nok3")
                 pass
 
             return False
@@ -76,4 +70,3 @@ def signed_req_required(view_func):
             raise Http404
 
     return wraps(view_func)(check_signature)
-

--- a/resigner/server.py
+++ b/resigner/server.py
@@ -33,12 +33,15 @@ def signed_req_required(view_func):
             max_delay = get_settings_param("RESIGNER_API_MAX_DELAY", 5*60)
             time_stamp_now = time.time()
 
-            return (
+            ts_valid = (
                 abs(int(time_stamp_now) - int(received_times_stamp)) < max_delay
             )
+            print("ts_valid {}".format(ts_valid))
+            return ts_valid
 
         def is_signature_ok():
             if not SERVER_API_SIGNATURE_KEY in request.META.keys():
+                print("is_signature_nok1")
                 return False
             api_signature = request.META[SERVER_API_SIGNATURE_KEY]
 
@@ -55,7 +58,10 @@ def signed_req_required(view_func):
                 if api_signature == expected_signature:
                     return True
 
+                print("is_signature_nok2")
+
             except:
+                print("is_signature_nok3")
                 pass
 
             return False

--- a/test_project/resigner_tests/tests.py
+++ b/test_project/resigner_tests/tests.py
@@ -119,7 +119,7 @@ class TestSignedApiBase(object):
             key = CLIENT_TIME_STAMP_KEY
             ts = req.headers[key.lower()]
             req.headers.update(
-                {key: str( int(ts) + diff )}
+                {key: str(float(ts) + diff)}
             )
 
         res = self.deconstructed_client_api_call(simulate_outdated_timestamp)


### PR DESCRIPTION
Fixes timestamp timeout happening randomly when RESIGNER_API_MAX_DELAY is small (like 1 second). This was affecting tests only ([example](https://travis-ci.org/mediapredict/resigner/builds/202334579)), since there we're using the value of 1.