### PR TITLE
Fix decoding timestamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ env:
     - DJANGO=1.10
     - DJANGO=1.11
     - DJANGO=2.0
-    - DJANGO=2.1
+    - DJANGO=2.1.8
 language: python
 python:
   - "3.6"
 
 install:
-  - pip install django==${DJANGO_VERSION}
+  - pip install django==${DJANGO}
   - pip install .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 env:
   matrix:
-    - DJANGO=1.9
-    - DJANGO=1.10
-    - DJANGO=1.11
     - DJANGO=2.0
     - DJANGO=2.1.8
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,13 @@
-language: python
-
-python:
-  - "2.7"
-  - "3.6"
-
 env:
-  - DJANGO_VERSION=1.7
-  - DJANGO_VERSION=1.8
-  - DJANGO_VERSION=1.9
-  - DJANGO_VERSION=1.10.5
-
-matrix:
-  allow_failures:
-    - env: DJANGO_VERSION=1.7
-      python: "3.6"
+  matrix:
+    - DJANGO=1.9
+    - DJANGO=1.10
+    - DJANGO=1.11
+    - DJANGO=2.0
+    - DJANGO=2.1
+language: python
+python:
+  - "3.6"
 
 install:
   - pip install django==${DJANGO_VERSION}

--- a/resigner/querystring.py
+++ b/resigner/querystring.py
@@ -10,7 +10,10 @@ from django.core.signing import Signer
 
 from resigner.models import ApiKey
 
+
 TIMESTAMP_TAG = "_timestamp"
+KEY_TAG = "key"
+SIGNATURE_TAG = "signature"
 
 
 class ValidationError(Exception):
@@ -27,8 +30,8 @@ def sign(params, key, secret):
     params = {str(k): str(v) for (k, v) in params.items()}
     timestamp = str(int(time.time()))
 
-    params["signature"] = _generate_signature(params, secret, timestamp)
-    params["key"] = key
+    params[SIGNATURE_TAG] = _generate_signature(params, secret, timestamp)
+    params[KEY_TAG] = key
     params[TIMESTAMP_TAG] = timestamp
 
     return "{}".format(urlencode(params))
@@ -37,12 +40,12 @@ def sign(params, key, secret):
 def validate(querystring, max_age=60*60):
     params = dict(parse_qsl(querystring))
 
-    for key in ["timestamp", "key", "signature", ]:
+    for key in [TIMESTAMP_TAG, KEY_TAG, SIGNATURE_TAG, ]:
         if key not in params:
             raise ValidationError("{0} must exist".format(key))
 
-    key = params.pop("key")
-    signature = params.pop("signature")
+    key = params.pop(KEY_TAG)
+    signature = params.pop(SIGNATURE_TAG)
 
     timestamp = params.pop(TIMESTAMP_TAG)
     time_stamp_expired = int(timestamp) + max_age

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name='resigner',
-    version='0.3.1',
+    version='0.3.2',
     author='Mediapredict',
     author_email='engineering@mediapredict.com',
     description=('Django app that provides a way to simply secure your APIs'),
@@ -18,7 +18,7 @@ setup(
     packages=['resigner', 'resigner.migrations'],
     package_data={},
     install_requires=[
-        "django >= 1.7",
+        "django >= 2.0",
         "requests >= 2.5",
         "future >= 0.16.0",
     ],

--- a/test_project/resigner_tests/tests.py
+++ b/test_project/resigner_tests/tests.py
@@ -4,7 +4,7 @@ import json
 import time
 
 from django.test import LiveServerTestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client
 
 from resigner.models import ApiKey


### PR DESCRIPTION
https://github.com/mediapredict/mediapredict/issues/2254

_&times_ in _&timestamp_ was getting replaced by `×` as seen here: https://www.w3schools.com/charsets/ref_html_entities_4.asp

Note
This should be deployed at the same time on the `kf` and `mp`. The best time to do so is outside office hours.